### PR TITLE
Feature/67740  Add Kubernetes context validation and kubectl dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ If you need more detailed output, use the `--verbose` flag to enable verbose log
 ```
 helm quix-manager update --repo oci://charts.example.com/helm:latest --verbose
 ```
+
+#### Context Validation
+To confirm the Kubernetes context before proceeding with the operation, use the `--validate-context` flag:
+
+```
+helm quix-manager update --repo oci://charts.example.com/helm:latest --validate-context
+```
+
+This will prompt you to confirm if you want to use the current Kubernetes context before proceeding with the operation.
+
 #### Logs as Configmap
 For CI/CD integration (e.g., ArgoCD), the `--logs-as-config` flag allows you to generate a Kubernetes ConfigMap with the logs from the Helm operation:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To use the quix-manager plugin, ensure the following dependencies are installed:
 - python 3.9+
 - git
 - helm
+- kubectl
 
 ## Installation
 

--- a/quix_install_command.py
+++ b/quix_install_command.py
@@ -1,5 +1,6 @@
 import argparse, logging,io, yaml
 from src.helm_manager import  HelmManager
+import subprocess
 
 
 
@@ -17,6 +18,28 @@ def generate_configmap(logs, configmap_name='quix-manager-log-configmap', namesp
         }
     }
     return configmap
+
+def get_current_context():
+    try:
+        result = subprocess.run(['kubectl', 'config', 'current-context'], 
+                              capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+def confirm_current_context():
+    current_context = get_current_context()
+    if not current_context:
+        print("No Kubernetes context is currently set")
+        return False
+        
+    while True:
+        response = input(f"Do you want to use this context? ({current_context}) [y/n]: ").lower()
+        if response in ['y', 'yes']:
+            return True
+        elif response in ['n', 'no']:
+            return False
+        print("Please answer 'y' or 'n'")
 
 def setup_logging(verbose: bool):
     # Define the log format
@@ -58,12 +81,20 @@ if __name__ == "__main__":
     parser.add_argument('--timeout', help='Specify the timeout for the Helm command')
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output for this script and the Helm command')
     parser.add_argument('--logs-as-config', action='store_true', help='Write in the stdout a configmap with all logs happened. This is essentially for argocd')
+    parser.add_argument('--validate-context', action='store_true', help='Ask for confirmation before using the current Kubernetes context')
     
 
     # Get the args from command
     args, _ = parser.parse_known_args()
+    
     # Set up logging
     logger, log_stream = setup_logging(args.verbose)
+    
+    # Validate current context only if requested
+    if args.validate_context:
+        if not confirm_current_context():
+            logger.info("Operation cancelled by user")
+            exit(0)
 
     logger.info("Starting Helm command execution")
     # Log some initial info

--- a/quix_install_command.py
+++ b/quix_install_command.py
@@ -1,6 +1,7 @@
 import argparse, logging,io, yaml
 from src.helm_manager import  HelmManager
 import subprocess
+import shutil
 
 
 
@@ -18,6 +19,12 @@ def generate_configmap(logs, configmap_name='quix-manager-log-configmap', namesp
         }
     }
     return configmap
+
+def check_kubectl_installed():
+    if shutil.which('kubectl') is None:
+        print("Error: kubectl is not installed or not found in PATH")
+        return False
+    return True
 
 def get_current_context():
     try:
@@ -86,6 +93,10 @@ if __name__ == "__main__":
 
     # Get the args from command
     args, _ = parser.parse_known_args()
+    
+    # Check if kubectl is installed
+    if not check_kubectl_installed():
+        exit(1)
     
     # Set up logging
     logger, log_stream = setup_logging(args.verbose)


### PR DESCRIPTION
# Add Kubernetes context validation and kubectl dependency check

## Summary
This PR adds two new features to improve the safety and reliability of the Quix Manager Helm plugin:

1. **Kubernetes Context Validation**
   - Added a new `--validate-context` flag that prompts for confirmation before using the current Kubernetes context
   - Provides an interactive way to verify the target cluster before executing Helm operations
   - Helps prevent accidental deployments to wrong clusters

2. **Kubectl Dependency Check**
   - Added automatic verification of kubectl installation
   - Script now checks for kubectl availability before executing any operations
   - Provides clear error message if kubectl is not found in PATH
   - Added kubectl to the prerequisites in documentation

## Changes
- Added new functions `check_kubectl_installed()` and `confirm_current_context()`
- Added new command line parameter `--validate-context`
- Updated README.md with new parameter documentation and prerequisites
- Added early validation of kubectl dependency

## Documentation
- Updated README.md with new parameter documentation
- Added kubectl to the prerequisites list
- Added example usage of the new `--validate-context` flag